### PR TITLE
Update library to dual target the full framework

### DIFF
--- a/src/MSMQ.Messaging.csproj
+++ b/src/MSMQ.Messaging.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net472</TargetFrameworks>
     <UseWindowsForms>true</UseWindowsForms>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AssemblyName>MSMQ.Messaging</AssemblyName>

--- a/src/Messaging/MessageQueue.cs
+++ b/src/Messaging/MessageQueue.cs
@@ -141,8 +141,10 @@ namespace MSMQ.Messaging
         {
             try
             {
-                using TelemetryEventSource eventSource = new TelemetryEventSource();
-                eventSource.MessageQueue();
+                using (TelemetryEventSource eventSource = new TelemetryEventSource())
+                {
+                    eventSource.MessageQueue();
+                }
             }
             catch
             {


### PR DESCRIPTION
I still have to support full framework apps while we're making the conversion to .NET core.  I'm sure I'm not the only one in this situation.  In support of this I've modified the target frameworks on the project.

I dropped this down to netstandard2 .0 to provide as much compatibility as possible across various runtimes.  This necessitated removing just one declarative using statement as netstandard2.0 does not support c# 8.  I've explicitly targetting the full frameworkt to ensure that System.Configuration.ConfigurationManager isn't a dependency when running on the full framework.  

I did remove netcoreapp3.1 as I'm not sure that accomplishes anything over netstandard2.0.  If you'd like it added I can update the PR to re-add it. 