### PR TITLE
fix String resources

### DIFF
--- a/src/Messaging/Res.cs
+++ b/src/Messaging/Res.cs
@@ -280,7 +280,7 @@ namespace MSMQ.Messaging
 
         internal Res()
         {
-            this.resources = new ResourceManager("System.Properties.Resources", typeof(Properties.Resources).Assembly);
+            this.resources = new ResourceManager("MSMQ.Properties.Resources", typeof(Properties.Resources).Assembly);
         }
 
         private static Res GetLoader()


### PR DESCRIPTION
Any access to the resources currently fails with:

System.Resources.MissingManifestResourceException : Could not find the resource "System.Properties.Resources.resources" among the resources "MSMQ.Properties.Resources.resources" embedded in the assembly "MSMQ.Messaging", nor among the resources in any satellite assemblies for the specified culture. Perhaps the resources were embedded with an incorrect name.
   at System.Resources.ManifestBasedResourceGroveler.HandleResourceStreamMissing(String fileName)
   at System.Resources.ManifestBasedResourceGroveler.GrovelForResourceSet(CultureInfo culture, Dictionary`2 localResourceSets, Boolean tryParents, Boolean createIfNotExists)
   at System.Resources.ResourceManager.InternalGetResourceSet(CultureInfo culture, Boolean createIfNotExists, Boolean tryParents)
   at System.Resources.ResourceManager.GetString(String name, CultureInfo culture)
   at MSMQ.Messaging.Res.GetString(String name) in C:\Users\mariu\Desktop\MSMQ.Messaging\src\Messaging\Res.cs:line 318
   at MSMQ.Messaging.Interop.SafeNativeMethods.MQPathNameToFormatName(String pathName, StringBuilder formatName, Int32& count) in C:\Users\mariu\Desktop\MSMQ.Messaging\src\Messaging\Interop\SafeNativeMethods.cs:line 47
   at MSMQ.Messaging.MessageQueue.ResolveFormatNameFromQueuePath(String queuePath, Boolean throwException) in C:\Users\mariu\Desktop\MSMQ.Messaging\src\Messaging\MessageQueue.cs:line 3351
   at MSMQ.Messaging.MessageQueue.Exists(String path) in C:\Users\mariu\Desktop\MSMQ.Messaging\src\Messaging\MessageQueue.cs:line 1828
   at MSMQ.Messaging.Tests.MessageQueueTests..ctor() in C:\Users\mariu\Desktop\MSMQ.Messaging\tests\Tests\MessageQueueTests.cs:line 14