### PR TITLE
InvalidCastException when sending MSMQ message

### DIFF
--- a/src/Messaging/Interop/MessagePropertyVariants.cs
+++ b/src/Messaging/Interop/MessagePropertyVariants.cs
@@ -309,10 +309,8 @@ namespace MSMQ.Messaging.Interop
                     newVectorProperties[usedProperties].vt = vt;
                     if (vt == (short)(VT_VECTOR | VT_UI1))
                     {
-                        bool isGcHandle = false;
                         if (handles[i] == null || handles[i] is GCHandle)
                         {
-                            isGcHandle = handles[i] is GCHandle;
                             newVectorProperties[usedProperties].caub.cElems = (uint)((byte[])objects[i]).Length;
                         }
                         else

--- a/src/Messaging/Interop/MessagePropertyVariants.cs
+++ b/src/Messaging/Interop/MessagePropertyVariants.cs
@@ -344,10 +344,6 @@ namespace MSMQ.Messaging.Interop
             }
 
             handleVectorIdentifiers = GCHandle.Alloc(newVectorIdentifiers, GCHandleType.Pinned);
-            if (!handleVectorIdentifiers.IsAllocated)
-            {
-                Console.WriteLine();
-            }
 
             handleVectorProperties = GCHandle.Alloc(newVectorProperties, GCHandleType.Pinned);
             handleVectorStatus = GCHandle.Alloc(newVectorStatus, GCHandleType.Pinned);


### PR DESCRIPTION
We are using your library under .net core and have discovered that, at least it seems, when the code is under load (~10 req/sec) we get the following exception: 

![image](https://user-images.githubusercontent.com/526471/157115942-1fddb31b-668e-43b4-906a-b838ea9c2b07.png)

I'm not entirely sure what all the code in here is doing, but it appears to be constructing COM property arrays (presumably for placing/serializing into MSMQ). Maybe? I haven't dealt with MSMQ at this level before. Regardless, a particular function of yours has me curious that perhaps we're running into some issues with a collision of intent of an array: 

![image](https://user-images.githubusercontent.com/526471/157116140-3e575efa-fef7-455d-bade-1aefd985df0f.png)

When looking at the code that's crashing, I see you're casing it and thereby treating it as a uint at the time of the crash. However, the object in the array at that index is a GCHandle (which seems to be the second intent of the handles array). Maybe the fact you're using this array to store different things is causing an issue? Or perhaps index collisions? 

Without knowing all of the specifics I modified your code to be more mindful of nullity and the underlying types. It seems to have prevented the crash we're experiencing. But I'm opening this PR to open a discussion and not to necessarily recommend this code as-is. I just don't understand what's going on underneath to say for sure if this is even a valid fix. 

One last thing: when I cleaned up the code to be mindful of whether the underying type as a GCHandle, I had to also be aware to not call .Free() on a null object. It seems as though the GCHandle, if it exists, was being freed and collected previously. I tried to determine if there was anything async going on (threads stomping on each other), by putting things inside lock statements, but to not avail. 
